### PR TITLE
feat: show Claude & GPT quota grouped separately

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-node_modules/
+node_modules
 dist/
 .refs/
 *.log

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ dsh plugin --profile web add github:LiZhenNet/dsh-antigravity
 
 ```sh
 npm run pack:dist
-dsh plugin --profile web add ./dist/dsh-antigravity-0.0.1.tgz
+dsh plugin --profile web add ./dist/dsh-antigravity-0.0.2.tgz
 ```
 
 The package declares a DSH bundle patch, so installation automatically mounts
@@ -60,7 +60,12 @@ Google OAuth and refreshes quota after login completes.
 
 ![Antigravity Settings - Not Signed In](./assets/images/settings-not-signed-in.png)
 
-After login, the settings page displays account information, live quota bars, reset times, and model selector options:
+After login, the settings page displays account information, quota grouped by model family, reset times, and model selector options:
+
+- **Gemini Models** — Gemini Flash / Pro variants share one quota pool (green bars).
+- **Claude and GPT models** — Claude Opus, Claude Sonnet, and GPT-OSS share a separate 3P quota pool (cyan bars).
+
+Each group shows a **5-hour limit** (smooths short-term demand) and a **weekly limit** (tied to your subscription tier) with a live countdown to reset.
 
 ![Antigravity Settings - Signed In with Quota](./assets/images/settings-signed-in.png)
 
@@ -82,21 +87,29 @@ Keep that file private. It contains access and refresh tokens.
 
 ## Models
 
-After login, select the **Antigravity** provider in DSH's model picker.
+After login, select the **Antigravity** provider in DSH's model picker. Use the
+model selector in **Settings > Antigravity** to enable or disable individual
+models — the live remaining quota percentage is shown next to each one.
 
 Registered model IDs:
 
-- `gemini-3.7-flash` (Gemini 3.7 Flash)
-- `gemini-3.6-flash` (Gemini 3.6 Flash)
-- `gemini-3.5-flash` (Gemini 3.5 Flash)
-- `gemini-3.1-pro` (Gemini 3.1 Pro)
-- `gemini-3.1-flash-image` (Gemini 3.1 Flash Image)
-- `gemini-3-flash` (Gemini 3 Flash)
-- `gemini-2.5-pro` (Gemini 2.5 Pro)
-- `gemini-2.5-flash` (Gemini 2.5 Flash)
-- `claude-opus-4-6` (Claude Opus 4.6)
-- `claude-sonnet-4-6` (Claude Sonnet 4.6)
-- `gpt-oss-120b` (GPT-OSS 120B)
+| Model ID | Name | Quota pool |
+|---|---|---|
+| `gemini-3.7-flash` | Gemini 3.7 Flash | Gemini |
+| `gemini-3.6-flash` | Gemini 3.6 Flash | Gemini |
+| `gemini-3.5-flash` | Gemini 3.5 Flash | Gemini |
+| `gemini-3.1-pro` | Gemini 3.1 Pro | Gemini |
+| `gemini-3.1-flash-image` | Gemini 3.1 Flash Image | Gemini |
+| `gemini-3-flash` | Gemini 3 Flash | Gemini |
+| `gemini-2.5-pro` | Gemini 2.5 Pro | Gemini |
+| `gemini-2.5-flash` | Gemini 2.5 Flash | Gemini |
+| `claude-opus-4-6` | Claude Opus 4.6 | Claude & GPT (3P) |
+| `claude-sonnet-4-6` | Claude Sonnet 4.6 | Claude & GPT (3P) |
+| `gpt-oss-120b` | GPT-OSS 120B | Claude & GPT (3P) |
+
+Models in the same quota pool share a weekly limit and a 5-hour limit. Quota is
+consumed proportionally to token cost, so heavier models (e.g. Claude Opus)
+drain the pool faster than lighter ones.
 
 The plugin resolves these public IDs to runtime model IDs using the live
 `fetchAvailableModels` catalog when available, with static routing fallbacks.

--- a/lib/client.js
+++ b/lib/client.js
@@ -71,13 +71,18 @@ window.__ModuleLoader__.load({
 .dsha-email-text{overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
 .dsha-badge{display:inline-flex;align-items:center;gap:6px;border-radius:999px;background:#eef2ff;color:#3f46d8;border:1px solid #dfe5ff;padding:4px 9px;font-size:12px;font-weight:800;letter-spacing:.02em}
 .dsha-diamond{width:8px;height:8px;border-radius:2px;background:#4f5bf6;transform:rotate(45deg)}
-.dsha-quota-title{margin:16px 0 4px;color:#111827;font-size:14px;font-weight:700}
-.dsha-row{padding:12px 0;border-top:1px solid #f0f2f5}
-.dsha-rowtop{display:flex;align-items:baseline;justify-content:space-between;gap:12px;color:#4b5563;font-weight:650;font-size:13px}
+.dsha-quota-title{margin:16px 0 6px;color:#111827;font-size:14px;font-weight:700}
+.dsha-quota-group{margin-top:10px;padding:12px 14px;background:#fafbfc;border:1px solid #eef1f5;border-radius:10px}
+.dsha-group-head{display:flex;align-items:baseline;justify-content:space-between;gap:8px;margin-bottom:8px;flex-wrap:wrap}
+.dsha-group-title{font-size:13px;font-weight:700;color:#111827}
+.dsha-group-desc{font-size:12px;color:#8b93a1}
+.dsha-row{padding:8px 0;border-top:1px solid #edf1f5}
+.dsha-row:first-of-type{border-top:0;padding-top:0}
+.dsha-rowtop{display:flex;align-items:baseline;justify-content:space-between;gap:12px;color:#4b5563;font-weight:600;font-size:13px}
 .dsha-metrics{display:flex;align-items:baseline;gap:10px;white-space:nowrap;color:#8b93a1;font-size:12px}
 .dsha-percent{font-size:13px;font-weight:750;color:#059669}
 .dsha-percent-cyan{color:#0284c7}
-.dsha-bar{height:6px;margin-top:8px;border-radius:999px;background:#edf1f5;overflow:hidden}
+.dsha-bar{height:6px;margin-top:6px;border-radius:999px;background:#edf1f5;overflow:hidden}
 .dsha-fill{height:100%;border-radius:999px;background:#10b981}
 .dsha-fill-cyan{background:#06b6d4}
 .dsha-empty{border:1px dashed #d8dee8;border-radius:10px;padding:14px;color:#747f90;background:#fafbfc;font-size:13px;line-height:20px}
@@ -198,29 +203,25 @@ window.__ModuleLoader__.load({
       return (a.name || a.id || "").localeCompare(b.name || b.id || "") || (a.id || "").localeCompare(b.id || "");
     }
 
-    function modelScore(row) {
-      const id = String(row.id || row.label || "").toLowerCase();
-      if (id.includes("gemini-3.1-pro")) return 10;
-      if (id.includes("gemini") && id.includes("image")) return 9;
-      if (id.includes("gemini-3.5")) return 8;
-      if (id.includes("claude-sonnet")) return 7;
-      if (id.includes("claude")) return 6;
-      return 1;
-    }
-
-    function chooseRows(quota) {
-      const models = Array.isArray(quota && quota.modelRows) ? quota.modelRows : [];
-      const withQuota = models.filter((row) => typeof row.remainingFraction === "number");
-      const selected = withQuota.length ? withQuota : models;
-      if (selected.length) {
-        return [...selected].sort((a, b) => modelScore(b) - modelScore(a)).slice(0, 4);
-      }
-      const buckets = Array.isArray(quota && quota.bucketRows) ? quota.bucketRows : [];
-      return buckets.slice(0, 4);
+    function formatReset(resetTime) {
+      if (!resetTime) return "n/a";
+      const timestamp = Date.parse(resetTime);
+      if (!Number.isFinite(timestamp)) return resetTime;
+      const delta = timestamp - Date.now();
+      if (delta <= 0) return "now";
+      const totalMinutes = Math.round(delta / 60000);
+      const days = Math.floor(totalMinutes / (60 * 24));
+      const hours = Math.floor((totalMinutes % (60 * 24)) / 60);
+      const minutes = totalMinutes % 60;
+      if (days > 0) return `${days}d ${hours}h`;
+      if (hours > 0) return `${hours}h ${minutes}m`;
+      return `${minutes}m`;
     }
 
     function resetText(row) {
-      return row && row.resetLabel ? `R: ${row.resetLabel}` : "R: n/a";
+      if (row && row.resetLabel) return `重置: ${row.resetLabel}`;
+      if (row && row.resetTime) return `重置: ${formatReset(row.resetTime)}`;
+      return "重置: n/a";
     }
 
     function percentOf(row) {
@@ -234,7 +235,7 @@ window.__ModuleLoader__.load({
       const width = Math.max(0, Math.min(100, percent));
       return React.createElement("div", { className: "dsha-row" },
         React.createElement("div", { className: "dsha-rowtop" },
-          React.createElement("div", null, row.label || row.id || "Quota"),
+          React.createElement("div", null, row.label || row.displayName || row.id || "Quota"),
           React.createElement("div", { className: "dsha-metrics" },
             React.createElement("span", null, resetText(row)),
             React.createElement("span", { className: `dsha-percent${accent === "cyan" ? " dsha-percent-cyan" : ""}` }, `${percent}%`),
@@ -249,11 +250,29 @@ window.__ModuleLoader__.load({
       );
     }
 
+    function QuotaGroup({ group, accent }) {
+      const buckets = Array.isArray(group && group.buckets) ? group.buckets : [];
+      return React.createElement("div", { className: "dsha-quota-group" },
+        React.createElement("div", { className: "dsha-group-head" },
+          React.createElement("span", { className: "dsha-group-title" }, group.displayName || "Quota group"),
+          group.description && React.createElement("span", { className: "dsha-group-desc" }, group.description),
+        ),
+        buckets.map((bucket, index) => React.createElement(QuotaRow, {
+          key: bucket.id || bucket.bucketId || bucket.label || bucket.displayName || index,
+          row: bucket,
+          accent,
+        })),
+      );
+    }
+
     function modelMeta(option) {
       const parts = [];
       if (Array.isArray(option.inputModalities) && option.inputModalities.includes("image")) parts.push("image");
       if (Array.isArray(option.reasoningEfforts) && option.reasoningEfforts.length) {
         parts.push(`thinking: ${option.reasoningEfforts.join("/")}`);
+      }
+      if (typeof option.remainingPercent === "number") {
+        parts.push(`额度: ${option.remainingPercent}%`);
       }
       return parts.join(" · ");
     }
@@ -313,7 +332,7 @@ window.__ModuleLoader__.load({
         let cancelled = false;
         void refreshStatus()
           .then((value) => {
-            if (!cancelled && value.authenticated && !value.quota) void refreshQuota();
+            if (!cancelled && value.authenticated) void refreshQuota();
           })
           .catch((err) => {
             if (!cancelled) {
@@ -402,7 +421,29 @@ window.__ModuleLoader__.load({
         void saveModels(ids);
       }, [modelConfig, saveModels]);
 
-      const rows = useMemo(() => chooseRows(quota), [quota]);
+      const quotaGroups = useMemo(() => {
+        if (!quota) return [];
+        if (Array.isArray(quota.groups) && quota.groups.length > 0) {
+          return quota.groups;
+        }
+        if (Array.isArray(quota.bucketRows) && quota.bucketRows.length > 0) {
+          const map = new Map();
+          for (const b of quota.bucketRows) {
+            const grp = b.group || "Quota";
+            if (!map.has(grp)) map.set(grp, []);
+            map.get(grp).push(b);
+          }
+          return [...map.entries()].map(([displayName, buckets]) => ({ displayName, buckets }));
+        }
+        return [];
+      }, [quota]);
+
+      const fallbackModelRows = useMemo(() => {
+        if (quotaGroups.length > 0) return [];
+        if (!quota || !Array.isArray(quota.modelRows)) return [];
+        return quota.modelRows.filter((row) => typeof row.remainingFraction === "number");
+      }, [quota, quotaGroups]);
+
       const modelOptions = useMemo(() => {
         const options = modelConfig && Array.isArray(modelConfig.options) ? modelConfig.options : [];
         return [...options].sort(compareAntigravityModels);
@@ -440,13 +481,24 @@ window.__ModuleLoader__.load({
             ),
           ),
           !status.authenticated && React.createElement("div", { className: "dsha-empty" }, "点击右上角登录后，会在浏览器中完成 Google OAuth，登录成功后这里会显示 quota。"),
-          status.authenticated && rows.length === 0 && React.createElement("div", { className: "dsha-empty" }, busy ? "正在获取 quota..." : "暂无 quota 数据，点击刷新。"),
-          status.authenticated && rows.length > 0 && React.createElement("div", { className: "dsha-quota-title" }, "额度"),
-          status.authenticated && rows.map((row, index) => React.createElement(QuotaRow, {
-            key: row.id || row.label || index,
-            row,
-            accent: /claude/i.test(`${row.id || ""} ${row.label || ""}`) ? "cyan" : "green",
-          })),
+          status.authenticated && !quota && React.createElement("div", { className: "dsha-empty" }, busy ? "正在获取 quota..." : "暂无 quota 数据，点击刷新。"),
+          status.authenticated && (quotaGroups.length > 0 || fallbackModelRows.length > 0) && React.createElement("div", { className: "dsha-quota-title" }, "额度"),
+          status.authenticated && quotaGroups.map((group, index) => {
+            const isCyan = /claude|gpt|3p|openai|anthropic/i.test(`${group.displayName || ""} ${group.description || ""}`);
+            return React.createElement(QuotaGroup, {
+              key: group.displayName || index,
+              group,
+              accent: isCyan ? "cyan" : "green",
+            });
+          }),
+          status.authenticated && quotaGroups.length === 0 && fallbackModelRows.map((row, index) => {
+            const isCyan = /claude|gpt|3p|openai|anthropic/i.test(`${row.id || ""} ${row.label || ""}`);
+            return React.createElement(QuotaRow, {
+              key: row.id || row.label || index,
+              row,
+              accent: isCyan ? "cyan" : "green",
+            });
+          }),
           error && React.createElement("div", { className: "dsha-error" }, error),
           quota && React.createElement("div", { className: "dsha-note" },
             `更新时间：${new Date(quota.fetchedAt).toLocaleString()}`,

--- a/lib/index.js
+++ b/lib/index.js
@@ -2772,7 +2772,7 @@ function sendMethodNotAllowed(response) {
 }
 
 function quotaCardRows(quota) {
-  const modelRows = quota.models
+  const modelRows = (quota.models || [])
     .filter((model) => !/tab_|chat_/i.test(model.modelId))
     .map((model) => ({
       id: model.modelId,
@@ -2786,18 +2786,34 @@ function quotaCardRows(quota) {
       supportsThinking: model.supportsThinking,
       supportsImages: model.supportsImages,
     }));
-  const bucketRows = quota.groups.flatMap((group) =>
-    group.buckets.map((bucket) => ({
+  const bucketRows = (quota.groups || []).flatMap((group) =>
+    (group.buckets || []).map((bucket) => ({
       id: bucket.bucketId,
       label: bucket.displayName,
       group: group.displayName,
+      window: bucket.window,
       remainingPercent: remainingPercent(bucket.remainingFraction),
       remainingFraction: bucket.remainingFraction,
       resetLabel: formatReset(bucket.resetTime),
       resetTime: bucket.resetTime,
+      description: bucket.description,
     })),
   );
-  return { modelRows, bucketRows };
+  const groups = (quota.groups || []).map((group) => ({
+    displayName: group.displayName,
+    description: group.description,
+    buckets: (group.buckets || []).map((bucket) => ({
+      id: bucket.bucketId,
+      label: bucket.displayName,
+      window: bucket.window,
+      remainingPercent: remainingPercent(bucket.remainingFraction),
+      remainingFraction: bucket.remainingFraction,
+      resetLabel: formatReset(bucket.resetTime),
+      resetTime: bucket.resetTime,
+      description: bucket.description,
+    })),
+  }));
+  return { modelRows, bucketRows, groups, groupDescription: quota.groupDescription };
 }
 
 function publicModelMatchNeedles(modelId) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-antigravity",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Google Antigravity / Cloud Code Assist model provider for DeepSeek Harness",
   "type": "module",
   "main": "lib/index.js",


### PR DESCRIPTION
## Summary

Previously the Antigravity settings page only showed up to 4 quota rows
via `chooseRows` / `modelScore`, which silently dropped Claude and GPT
quota because internal Gemini model variants filled the 4 slots first.

This PR fixes the display and adds automatic quota refresh on page open.

## Changes

### `lib/index.js` (backend)
- `quotaCardRows` now returns a structured `groups` array with
  `displayName`, `description`, and per-bucket `window` / `description` fields
- Added `|| []` guards on `quota.models` / `quota.groups` / `group.buckets`
  to prevent crashes on missing fields

### `lib/client.js` (frontend)
- **Removed** `chooseRows` / `modelScore` — the old `slice(0, 4)` was the
  root cause of Claude & GPT quota being hidden
- **Added** `QuotaGroup` component — renders each quota group in its own card:
  - �� **Gemini Models** — green progress bars
  - �� **Claude and GPT models** — cyan progress bars
  - Each group shows 5-hour limit + weekly limit with live reset countdown
- Model selector sub-label now shows live remaining quota %
- Quota auto-refreshes once when the settings page opens
- `resetText` label localised to Chinese (`重置:`)

### `README.md`
- Login section documents the two quota pools and color coding
- Models table adds **Quota pool** column

## Test
Verified via local symlink (`~/.dsh/profiles/web/node_modules/dsh-antigravity → local checkout`).
Both Gemini and Claude & GPT groups returned with correct remaining
fractions and reset times via `curl -X POST http://127.0.0.1:3088/antigravity/api/quota`.