### PR TITLE
Feat/support client i18n

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ dsh plugin --profile web add github:LiZhenNet/dsh-antigravity
 
 ```sh
 npm run pack:dist
-dsh plugin --profile web add ./dist/dsh-antigravity-0.0.3.tgz
+dsh plugin --profile web add ./dist/dsh-antigravity-0.0.4.tgz
 ```
 
 The package declares a DSH bundle patch, so installation automatically mounts

--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ Google Antigravity / Cloud Code Assist model provider for
 [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness).
 
 This is a DSH Web plugin. It registers a DSH `LlmAdapter`
-under provider route `antigravity`, stores OAuth credentials under DSH home, and
-talks to the Cloud Code Assist streaming API directly.
+under provider route `antigravity`, stores OAuth credentials under DSH home,
+talks to the Cloud Code Assist streaming API directly, and provides full bilingual (English & Simplified Chinese) i18n support in the Web settings page.
 
 > Unofficial integration. This project is not affiliated with or endorsed by
 > Google. Use it only with accounts and services you are authorized to access.

--- a/README.zh.md
+++ b/README.zh.md
@@ -26,7 +26,7 @@ dsh plugin --profile web add github:LiZhenNet/dsh-antigravity
 
 ```sh
 npm run pack:dist
-dsh plugin --profile web add ./dist/dsh-antigravity-0.0.3.tgz
+dsh plugin --profile web add ./dist/dsh-antigravity-0.0.4.tgz
 ```
 
 该 package 声明了 DSH bundle patch，安装后会自动挂载 host 插件与浏览器设置页面。

--- a/README.zh.md
+++ b/README.zh.md
@@ -8,7 +8,7 @@
 
 适用于 [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness) 的 Google Antigravity / Cloud Code Assist 模型提供商插件。
 
-这是一个 DSH Web 插件。它在 provider 路由 `antigravity` 下注册 DSH `LlmAdapter`，OAuth 凭证存储于 DSH home 目录下，直接与 Cloud Code Assist 流式 API 通信。
+这是一个 DSH Web 插件。它在 provider 路由 `antigravity` 下注册 DSH `LlmAdapter`，OAuth 凭证存储于 DSH home 目录下，直接与 Cloud Code Assist 流式 API 通信，并且 Web 设置页面完整支持中英文双语国际化（i18n）。
 
 > 非官方集成。本项目与 Google 无关，亦未获得 Google 认可。请仅在您有权访问的账号和服务中使用。
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -73,14 +73,21 @@ window.__ModuleLoader__.load({
     };
 
     function createTranslator(ctx) {
+      const boundT = (ctx && ctx.locale && typeof ctx.locale.bind === "function")
+        ? ctx.locale.bind(NS)
+        : null;
+
       return function t(key, params) {
-        if (ctx && ctx.locale && typeof ctx.locale.t === "function") {
+        if (boundT) {
           try {
-            const res = ctx.locale.t(`${NS}.${key}`, params);
-            if (res && res !== `${NS}.${key}`) return res;
+            const res = boundT(key, params);
+            if (res && res !== key && res !== `${NS}.${key}`) return res;
           } catch (_) {}
         }
-        const isZh = typeof navigator !== "undefined" && navigator.language && navigator.language.startsWith("zh");
+        const active = (ctx && ctx.locale && typeof ctx.locale.getLocale === "function")
+          ? ctx.locale.getLocale()?.active
+          : null;
+        const isZh = active ? active.startsWith("zh") : (typeof navigator !== "undefined" && navigator.language && navigator.language.startsWith("zh"));
         const dict = isZh ? zh : en;
         let text = dict[key] || en[key] || zh[key] || key;
         if (params && typeof params === "object") {
@@ -384,8 +391,17 @@ window.__ModuleLoader__.load({
       );
     }
 
-    function AntigravitySettings({ t }) {
-      const tr = t || ((k) => zh[k] || k);
+    function AntigravitySettings({ ctx }) {
+      const [, setLocaleRev] = useState(0);
+      useEffect(() => {
+        if (!ctx || !ctx.locale || typeof ctx.locale.subscribe !== "function") return;
+        return ctx.locale.subscribe(() => {
+          setLocaleRev((r) => r + 1);
+        });
+      }, [ctx]);
+
+      const tr = useMemo(() => createTranslator(ctx), [ctx]);
+
       const [status, setStatus] = useState({ loading: true });
       const [quota, setQuota] = useState(undefined);
       const [modelConfig, setModelConfig] = useState(undefined);
@@ -633,13 +649,12 @@ window.__ModuleLoader__.load({
         if (ctx.locale && typeof ctx.locale.register === "function") {
           ctx.locale.register(NS, { zh, en });
         }
-        const t = createTranslator(ctx);
         ctx.slots.inject("settings.section", () => ctx.slots.register({
           name: "settings.section",
           id: "antigravity",
           order: 12,
           label: () => "Antigravity",
-        }, (props) => React.createElement(AntigravitySettings, { ...props, t })));
+        }, (props) => React.createElement(AntigravitySettings, { ...props, ctx })));
       },
     };
   },

--- a/lib/client.js
+++ b/lib/client.js
@@ -6,8 +6,91 @@ window.__ModuleLoader__.load({
 
     const STYLE_ID = "dsh-antigravity-settings-style";
     const API = "/antigravity/api";
+    const NS = "dsh-antigravity";
     const ANTIGRAVITY_SVG_PATH =
       "M89.6992 93.695C94.3659 97.195 101.366 94.8617 94.9492 88.445C75.6992 69.7783 79.7825 18.445 55.8659 18.445C31.9492 18.445 36.0325 69.7783 16.7825 88.445C9.78251 95.445 17.3658 97.195 22.0325 93.695C40.1159 81.445 38.9492 59.8617 55.8659 59.8617C72.7825 59.8617 71.6159 81.445 89.6992 93.695Z";
+
+    const zh = {
+      pageDesc: "登录 Google Antigravity / Cloud Code Assist，并查看当前账号的共享额度。",
+      currentAccount: "当前账号",
+      login: "登录",
+      loggingIn: "登录中...",
+      refresh: "刷新",
+      refreshing: "刷新中...",
+      logout: "退出",
+      loading: "Loading...",
+      notSignedIn: "未登录",
+      notSignedInDesc: "点击右上角登录后，会在浏览器中完成 Google OAuth，登录成功后这里会显示 quota。",
+      noQuotaDesc: "暂无 quota 数据，点击刷新。",
+      fetchingQuota: "正在获取 quota...",
+      quota: "额度",
+      resetPrefix: "重置: {time}",
+      resetUnavailable: "重置: n/a",
+      resetNow: "现在",
+      timeDayHour: "{days}天 {hours}时",
+      timeHourMin: "{hours}h {minutes}m",
+      timeMin: "{minutes}m",
+      updatedAt: "更新时间：{time}",
+      modelSelector: "模型选择器",
+      modelSelectorDesc: "勾选后会出现在 DSH 的 Antigravity 模型列表中。",
+      selectAll: "全选",
+      unselectAll: "全不选",
+      loadingModels: "正在加载模型配置...",
+      modelSelectorNote: "勾选即自动保存。重新打开模型选择器即可看到最新列表；运行中的旧会话不受影响。",
+      quotaLabel: "额度: {percent}%",
+      loginFailed: "登录失败",
+    };
+
+    const en = {
+      pageDesc: "Sign in to Google Antigravity / Cloud Code Assist and view shared quotas.",
+      currentAccount: "Current Account",
+      login: "Sign in",
+      loggingIn: "Signing in...",
+      refresh: "Refresh",
+      refreshing: "Refreshing...",
+      logout: "Sign out",
+      loading: "Loading...",
+      notSignedIn: "Not signed in",
+      notSignedInDesc: "Click Sign in to complete Google OAuth in your browser. Quotas will appear here after login.",
+      noQuotaDesc: "No quota data yet. Click Refresh.",
+      fetchingQuota: "Fetching quota data...",
+      quota: "Quota",
+      resetPrefix: "Reset: {time}",
+      resetUnavailable: "Reset: n/a",
+      resetNow: "now",
+      timeDayHour: "{days}d {hours}h",
+      timeHourMin: "{hours}h {minutes}m",
+      timeMin: "{minutes}m",
+      updatedAt: "Updated at: {time}",
+      modelSelector: "Model Selector",
+      modelSelectorDesc: "Checked models will appear in DSH's Antigravity model list.",
+      selectAll: "Select all",
+      unselectAll: "Deselect all",
+      loadingModels: "Loading model configuration...",
+      modelSelectorNote: "Changes are saved automatically. Reopen the model picker to see the updated list; running sessions are unaffected.",
+      quotaLabel: "Quota: {percent}%",
+      loginFailed: "Login failed",
+    };
+
+    function createTranslator(ctx) {
+      return function t(key, params) {
+        if (ctx && ctx.locale && typeof ctx.locale.t === "function") {
+          try {
+            const res = ctx.locale.t(`${NS}.${key}`, params);
+            if (res && res !== `${NS}.${key}`) return res;
+          } catch (_) {}
+        }
+        const isZh = typeof navigator !== "undefined" && navigator.language && navigator.language.startsWith("zh");
+        const dict = isZh ? zh : en;
+        let text = dict[key] || en[key] || zh[key] || key;
+        if (params && typeof params === "object") {
+          for (const [k, v] of Object.entries(params)) {
+            text = text.replace(new RegExp(`\\{${k}\\}`, "g"), String(v));
+          }
+        }
+        return text;
+      };
+    }
 
     function patchNavIcon() {
       const spans = document.querySelectorAll("span");
@@ -210,25 +293,25 @@ window.__ModuleLoader__.load({
       return compareAntigravityModels(a, b);
     }
 
-    function formatReset(resetTime) {
+    function formatReset(resetTime, t) {
       if (!resetTime) return "n/a";
       const timestamp = Date.parse(resetTime);
       if (!Number.isFinite(timestamp)) return resetTime;
       const delta = timestamp - Date.now();
-      if (delta <= 0) return "now";
+      if (delta <= 0) return t ? t("resetNow") : "now";
       const totalMinutes = Math.round(delta / 60000);
       const days = Math.floor(totalMinutes / (60 * 24));
       const hours = Math.floor((totalMinutes % (60 * 24)) / 60);
       const minutes = totalMinutes % 60;
-      if (days > 0) return `${days}d ${hours}h`;
-      if (hours > 0) return `${hours}h ${minutes}m`;
-      return `${minutes}m`;
+      if (days > 0) return t ? t("timeDayHour", { days, hours }) : `${days}d ${hours}h`;
+      if (hours > 0) return t ? t("timeHourMin", { hours, minutes }) : `${hours}h ${minutes}m`;
+      return t ? t("timeMin", { minutes }) : `${minutes}m`;
     }
 
-    function resetText(row) {
-      if (row && row.resetLabel) return `重置: ${row.resetLabel}`;
-      if (row && row.resetTime) return `重置: ${formatReset(row.resetTime)}`;
-      return "重置: n/a";
+    function resetText(row, t) {
+      if (row && row.resetLabel) return t ? t("resetPrefix", { time: row.resetLabel }) : `Reset: ${row.resetLabel}`;
+      if (row && row.resetTime) return t ? t("resetPrefix", { time: formatReset(row.resetTime, t) }) : `Reset: ${formatReset(row.resetTime, t)}`;
+      return t ? t("resetUnavailable") : "Reset: n/a";
     }
 
     function percentOf(row) {
@@ -237,14 +320,14 @@ window.__ModuleLoader__.load({
       return 0;
     }
 
-    function QuotaRow({ row, accent }) {
+    function QuotaRow({ row, accent, t }) {
       const percent = percentOf(row);
       const width = Math.max(0, Math.min(100, percent));
       return React.createElement("div", { className: "dsha-row" },
         React.createElement("div", { className: "dsha-rowtop" },
-          React.createElement("div", null, row.label || row.displayName || row.id || "Quota"),
+          React.createElement("div", null, row.label || row.displayName || row.id || (t ? t("quota") : "Quota")),
           React.createElement("div", { className: "dsha-metrics" },
-            React.createElement("span", null, resetText(row)),
+            React.createElement("span", null, resetText(row, t)),
             React.createElement("span", { className: `dsha-percent${accent === "cyan" ? " dsha-percent-cyan" : ""}` }, `${percent}%`),
           ),
         ),
@@ -257,34 +340,35 @@ window.__ModuleLoader__.load({
       );
     }
 
-    function QuotaGroup({ group, accent }) {
+    function QuotaGroup({ group, accent, t }) {
       const buckets = Array.isArray(group && group.buckets) ? group.buckets : [];
       return React.createElement("div", { className: "dsha-quota-group" },
         React.createElement("div", { className: "dsha-group-head" },
-          React.createElement("span", { className: "dsha-group-title" }, group.displayName || "Quota group"),
+          React.createElement("span", { className: "dsha-group-title" }, group.displayName || (t ? t("quota") : "Quota group")),
           group.description && React.createElement("span", { className: "dsha-group-desc" }, group.description),
         ),
         buckets.map((bucket, index) => React.createElement(QuotaRow, {
           key: bucket.id || bucket.bucketId || bucket.label || bucket.displayName || index,
           row: bucket,
           accent,
+          t,
         })),
       );
     }
 
-    function modelMeta(option) {
+    function modelMeta(option, t) {
       const parts = [];
       if (Array.isArray(option.inputModalities) && option.inputModalities.includes("image")) parts.push("image");
       if (Array.isArray(option.reasoningEfforts) && option.reasoningEfforts.length) {
         parts.push(`thinking: ${option.reasoningEfforts.join("/")}`);
       }
       if (typeof option.remainingPercent === "number") {
-        parts.push(`额度: ${option.remainingPercent}%`);
+        parts.push(t ? t("quotaLabel", { percent: option.remainingPercent }) : `Quota: ${option.remainingPercent}%`);
       }
       return parts.join(" · ");
     }
 
-    function ModelOptionRow({ option, disabled, onToggle }) {
+    function ModelOptionRow({ option, disabled, onToggle, t }) {
       return React.createElement("label", { className: "dsha-model-row" },
         React.createElement("input", {
           className: "dsha-check",
@@ -295,12 +379,13 @@ window.__ModuleLoader__.load({
         }),
         React.createElement("span", { className: "dsha-model-text" },
           React.createElement("span", { className: "dsha-model-name" }, option.name || option.id),
-          React.createElement("span", { className: "dsha-model-sub" }, modelMeta(option) || option.id),
+          React.createElement("span", { className: "dsha-model-sub" }, modelMeta(option, t) || option.id),
         ),
       );
     }
 
-    function AntigravitySettings() {
+    function AntigravitySettings({ t }) {
+      const tr = t || ((k) => zh[k] || k);
       const [status, setStatus] = useState({ loading: true });
       const [quota, setQuota] = useState(undefined);
       const [modelConfig, setModelConfig] = useState(undefined);
@@ -371,7 +456,7 @@ window.__ModuleLoader__.load({
               if (next.login && next.login.status === "error") {
                 window.clearInterval(pollRef.current);
                 pollRef.current = undefined;
-                setError(next.login.error || "Login failed");
+                setError(next.login.error || tr("loginFailed"));
               }
             } catch (err) {
               setError(err instanceof Error ? err.message : String(err));
@@ -382,7 +467,7 @@ window.__ModuleLoader__.load({
         } finally {
           setBusy(false);
         }
-      }, [refreshQuota, refreshStatus]);
+      }, [refreshQuota, refreshStatus, tr]);
 
       const logout = useCallback(async () => {
         setBusy(true);
@@ -457,45 +542,46 @@ window.__ModuleLoader__.load({
       }, [modelConfig]);
       const plan = quota && quota.planLabel ? quota.planLabel : "";
       const isPro = /pro|paid|plus/i.test(plan);
-      const email = status.email || "Not signed in";
+      const email = status.email || (status.loading ? tr("loading") : tr("notSignedIn"));
 
       return React.createElement("div", { className: "dsha-wrap" },
         React.createElement("div", { className: "dsha-page-head" },
           React.createElement(AntigravityIcon, { size: 24, className: "dsha-brand-icon" }),
           React.createElement("h2", { className: "dsha-page-title" }, "Antigravity"),
         ),
-        React.createElement("p", { className: "dsha-page-desc" }, "登录 Google Antigravity / Cloud Code Assist，并查看当前账号的共享额度。"),
+        React.createElement("p", { className: "dsha-page-desc" }, tr("pageDesc")),
         React.createElement("section", { className: "dsha-card" },
           React.createElement("div", { className: "dsha-head" },
             React.createElement("div", { className: "dsha-title" },
               React.createElement(AntigravityIcon, { size: 18, className: "dsha-brand-icon" }),
-              React.createElement("span", null, "当前账号"),
+              React.createElement("span", null, tr("currentAccount")),
             ),
             React.createElement("div", { className: "dsha-actions" },
-              !status.authenticated && React.createElement("button", { className: "dsha-btn dsha-btn-primary", disabled: busy, onClick: startLogin }, busy ? "登录中..." : "登录"),
-              status.authenticated && React.createElement("button", { className: "dsha-btn dsha-btn-primary", disabled: busy, onClick: refreshQuota }, busy ? "刷新中..." : "刷新"),
-              status.authenticated && React.createElement("button", { className: "dsha-btn", disabled: busy, onClick: logout }, "退出"),
+              !status.authenticated && React.createElement("button", { className: "dsha-btn dsha-btn-primary", disabled: busy, onClick: startLogin }, busy ? tr("loggingIn") : tr("login")),
+              status.authenticated && React.createElement("button", { className: "dsha-btn dsha-btn-primary", disabled: busy, onClick: refreshQuota }, busy ? tr("refreshing") : tr("refresh")),
+              status.authenticated && React.createElement("button", { className: "dsha-btn", disabled: busy, onClick: logout }, tr("logout")),
             ),
           ),
           React.createElement("div", { className: "dsha-account" },
             React.createElement("div", { className: "dsha-email" },
               React.createElement("span", { className: "dsha-email-mark", "aria-hidden": "true" }),
-              React.createElement("span", { className: "dsha-email-text" }, status.loading ? "Loading..." : email),
+              React.createElement("span", { className: "dsha-email-text" }, email),
             ),
             isPro && React.createElement("span", { className: "dsha-badge" },
               React.createElement("span", { className: "dsha-diamond", "aria-hidden": "true" }),
               "PRO",
             ),
           ),
-          !status.authenticated && React.createElement("div", { className: "dsha-empty" }, "点击右上角登录后，会在浏览器中完成 Google OAuth，登录成功后这里会显示 quota。"),
-          status.authenticated && !quota && React.createElement("div", { className: "dsha-empty" }, busy ? "正在获取 quota..." : "暂无 quota 数据，点击刷新。"),
-          status.authenticated && (quotaGroups.length > 0 || fallbackModelRows.length > 0) && React.createElement("div", { className: "dsha-quota-title" }, "额度"),
+          !status.authenticated && React.createElement("div", { className: "dsha-empty" }, tr("notSignedInDesc")),
+          status.authenticated && !quota && React.createElement("div", { className: "dsha-empty" }, busy ? tr("fetchingQuota") : tr("noQuotaDesc")),
+          status.authenticated && (quotaGroups.length > 0 || fallbackModelRows.length > 0) && React.createElement("div", { className: "dsha-quota-title" }, tr("quota")),
           status.authenticated && quotaGroups.map((group, index) => {
             const isCyan = /claude|gpt|3p|openai|anthropic/i.test(`${group.displayName || ""} ${group.description || ""}`);
             return React.createElement(QuotaGroup, {
               key: group.displayName || index,
               group,
               accent: isCyan ? "cyan" : "green",
+              t: tr,
             });
           }),
           status.authenticated && quotaGroups.length === 0 && fallbackModelRows.map((row, index) => {
@@ -504,50 +590,56 @@ window.__ModuleLoader__.load({
               key: row.id || row.label || index,
               row,
               accent: isCyan ? "cyan" : "green",
+              t: tr,
             });
           }),
           error && React.createElement("div", { className: "dsha-error" }, error),
           quota && React.createElement("div", { className: "dsha-note" },
-            `更新时间：${new Date(quota.fetchedAt).toLocaleString()}`,
+            tr("updatedAt", { time: new Date(quota.fetchedAt).toLocaleString() }),
           ),
         ),
         status.authenticated && React.createElement("section", { className: "dsha-card dsha-model-card" },
           React.createElement("div", { className: "dsha-model-head" },
             React.createElement("div", null,
-              React.createElement("div", { className: "dsha-model-title" }, "模型选择器"),
-              React.createElement("div", { className: "dsha-model-desc" }, "勾选后会出现在 DSH 的 Antigravity 模型列表中。"),
+              React.createElement("div", { className: "dsha-model-title" }, tr("modelSelector")),
+              React.createElement("div", { className: "dsha-model-desc" }, tr("modelSelectorDesc")),
             ),
             React.createElement("div", { className: "dsha-mini-actions" },
-              React.createElement("button", { className: "dsha-mini-btn", disabled: modelBusy, onClick: () => setAllModels(true) }, "全选"),
-              React.createElement("button", { className: "dsha-mini-btn", disabled: modelBusy, onClick: () => setAllModels(false) }, "全不选"),
+              React.createElement("button", { className: "dsha-mini-btn", disabled: modelBusy, onClick: () => setAllModels(true) }, tr("selectAll")),
+              React.createElement("button", { className: "dsha-mini-btn", disabled: modelBusy, onClick: () => setAllModels(false) }, tr("unselectAll")),
             ),
           ),
           modelOptions.length === 0
-            ? React.createElement("div", { className: "dsha-empty" }, "正在加载模型配置...")
+            ? React.createElement("div", { className: "dsha-empty" }, tr("loadingModels"))
             : React.createElement("div", { className: "dsha-model-list" },
                 modelOptions.map((option) => React.createElement(ModelOptionRow, {
                   key: option.id,
                   option,
                   disabled: modelBusy,
                   onToggle: toggleModel,
+                  t: tr,
                 })),
               ),
-          React.createElement("div", { className: "dsha-note" }, "勾选即自动保存。重新打开模型选择器即可看到最新列表；运行中的旧会话不受影响。"),
+          React.createElement("div", { className: "dsha-note" }, tr("modelSelectorNote")),
         ),
       );
     }
 
     return {
-      inject: ["slots"],
+      inject: ["slots", "locale"],
       apply(ctx) {
         installStyle();
         initNavObserver();
+        if (ctx.locale && typeof ctx.locale.register === "function") {
+          ctx.locale.register(NS, { zh, en });
+        }
+        const t = createTranslator(ctx);
         ctx.slots.inject("settings.section", () => ctx.slots.register({
           name: "settings.section",
           id: "antigravity",
           order: 12,
           label: () => "Antigravity",
-        }, AntigravitySettings));
+        }, (props) => React.createElement(AntigravitySettings, { ...props, t })));
       },
     };
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-antigravity",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "Google Antigravity / Cloud Code Assist model provider for DeepSeek Harness",
   "type": "module",
   "main": "lib/index.js",
@@ -16,7 +16,8 @@
     },
     "client": {
       "inject": [
-        "@deepseek-ai/dsh-client-ui-settings"
+        "@deepseek-ai/dsh-client-ui-settings",
+        "@deepseek-ai/dsh-client-locale"
       ],
       "platform": "web"
     }


### PR DESCRIPTION
## Summary

- **Bilingual i18n Support**: Added full English (`en`) and Simplified Chinese (`zh`) dictionaries for the Web settings page (`lib/client.js`).
- **Dynamic Locale Binding & Real-time Subscription**:
  - Registered `dsh-antigravity` namespace via `ctx.locale.register`.
  - Bound locale translator dynamically using `ctx.locale.bind("dsh-antigravity")`.
  - Subscribed to `ctx.locale.subscribe` inside the React settings component so all UI copy instantly reacts to language changes (e.g. switching between English and 中文 under **Settings > General > Language**).
- **Service Dependency Declaration**: Added `@deepseek-ai/dsh-client-locale` to `package.json` under `dsh.client.inject` and `inject: ["slots", "locale"]` in `lib/client.js`.
- **Documentation**: Updated `README.md` and `README.zh.md` to document the i18n capabilities and updated local release tarball instructions to `v0.0.4`.
- **Version Bump**: Bumped package version to `v0.0.4`.

## Changes

- `lib/client.js`:
  - Defined `zh` and `en` message dictionaries.
  - Implemented dynamic translator `createTranslator(ctx)` with fallback support.
  - Subscribed `AntigravitySettings` to `ctx.locale.subscribe`.
  - Replaced hardcoded strings across account, buttons, quota bars, countdown timers, and model selector with translated keys.
- `package.json`:
  - Bumped version `0.0.3` -> `0.0.4`.
  - Added `@deepseek-ai/dsh-client-locale` to `dsh.client.inject`.
- `README.md` & `README.zh.md`: Updated install paths and bilingual support highlights.

## Verification

- [x] Ran `npm run check` (`node --check`) with zero errors.
- [x] Verified via `browser-skill` automated browser testing:
  - English locale renders all page copy (page description, account, refresh/logout buttons, quota groups, reset timers, and model selector) in English.
  - Chinese locale renders properly in Chinese.
  - Live model selector prioritizes enabled models to the top as expected.